### PR TITLE
minor fixes for Mingw64 build

### DIFF
--- a/include/lldb/Host/windows/win32.h
+++ b/include/lldb/Host/windows/win32.h
@@ -93,7 +93,7 @@ int inline snprintf(char *buffer, size_t count, const char *format, ...)
 
 // timespec
 // MSVC 2015 and higher have timespec.  Otherwise we need to define it ourselves.
-#if defined(_MSC_VER) && _MSC_VER >= 1900
+#if defined(_MSC_VER) && _MSC_VER >= 1900 || defined(__MINGW32__)
 #include <time.h>
 #else
 struct timespec

--- a/include/lldb/Host/windows/win32.h
+++ b/include/lldb/Host/windows/win32.h
@@ -14,9 +14,11 @@
 #include <time.h>
 
 // posix utilities
+#ifndef __MINGW32__
 int vasprintf(char **ret, const char *fmt, va_list ap);
 char * strcasestr(const char *s, const char* find);
 char* realpath(const char * name, char * resolved);
+#endif
 
 #ifndef PATH_MAX
 #define PATH_MAX 32768

--- a/source/Initialization/SystemInitializerCommon.cpp
+++ b/source/Initialization/SystemInitializerCommon.cpp
@@ -174,7 +174,7 @@ SystemInitializerCommon::Terminate()
     PlatformDarwinKernel::Terminate();
 #endif
 
-#if defined(__WIN32__)
+#if defined(_MSC_VER)
     ProcessWindowsLog::Terminate();
 #endif
 


### PR DESCRIPTION
A few fixes to get the build along to the actual pain point, which is still `call_once` and the other threading primitives. But now there is a liquid metallic incentive to motivate working on it (not to mention the recently updated threading branch itself).